### PR TITLE
(maint) Move service logic to a module

### DIFF
--- a/lib/shared/puppet_self_service.rb
+++ b/lib/shared/puppet_self_service.rb
@@ -1,0 +1,49 @@
+require 'puppet'
+
+# PuppetSelfService - Shared code for Puppet Self Service facts
+module PuppetSelfService
+  # Gets the resource object by name
+  # @param resource [String] The resource type to get
+  # @param name [String] The name of the resource
+  # @return [Puppet::Type] The instance of the resource or nil
+  def self.get_resource(resource, name)
+    if resource == 'service'
+      Puppet::Type.type(resource.to_sym).instances.find { |s| s.name.split('.').first == name }
+    else
+      Puppet::Type.type(resource.to_sym).instances.find { |s| s.name == name }
+    end
+  end
+
+  # Check if the service is running
+  # @param name [String] The name of the service
+  # @param service [Puppet::Type::Service] An optional service resource to use
+  # @return [Boolean] True if the service is running
+  def self.service_running(name, service = nil)
+    service ||= get_resource('service', name)
+    return false if service.nil?
+
+    service.to_resource[:ensure] == :running
+  end
+
+  # Check if the service is enabled
+  # @param name [String] The name of the service
+  # @param service [Puppet::Type::Service] An optional service resource to use
+  # @return [Boolean] True if the service is enabled
+  def self.service_enabled(name, service = nil)
+    service ||= get_resource('service', name)
+    return false if service.nil?
+
+    service.to_resource[:enable].to_s.casecmp('true').zero?
+  end
+
+  # Check if the service is running and enabled
+  # @param name [String] The name of the service
+  # @param service [Puppet::Type::Service] An optional service resource to use
+  # @return [Boolean] True if the service is running and enabled
+  def self.service_running_enabled(name, service = nil)
+    service ||= get_resource('service', name)
+    return false if service.nil?
+
+    service_running(name, service) and service_enabled(name, service)
+  end
+end


### PR DESCRIPTION
Prior to this commit, the logic for checking the service state depended
on running the `puppet resource` face from an exec. This commit adds
some code to use `Puppet::Type` and provides methods to check the
service states in a shared module.