### PR TITLE
Adds a check to S0008 with a filesystem free method

### DIFF
--- a/lib/shared/puppet_self_service.rb
+++ b/lib/shared/puppet_self_service.rb
@@ -46,4 +46,14 @@ module PuppetSelfService
 
     service_running(name, service) and service_enabled(name, service)
   end
+
+  # Get the free disk percentage from a path
+  # @param name [String] The path on the file system
+  # @return [Integer] The percentage of used disk space
+  def self.filesystem_free(path)
+    require 'sys/filesystem'
+
+    stat = Sys::Filesystem.stat(path)
+    (stat.blocks_available.to_f / stat.blocks.to_f * 100).to_i
+  end
 end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -15,13 +15,8 @@ describe 'self_service class' do
     # Test Confirms all facts are false which is another indicator the class is performing correctly
     describe 'check no self_service fact is false' do
       it 'if idempotent all facts should be true' do
-        expect(host_inventory['facter']['self_service']['S0001']).to eq true
-        expect(host_inventory['facter']['self_service']['S0002']).to eq true
-        expect(host_inventory['facter']['self_service']['S0003']).to eq true
-        expect(host_inventory['facter']['self_service']['S0004']).to eq true
-        expect(host_inventory['facter']['self_service']['S0005']).to eq true
-        expect(host_inventory['facter']['self_service']['S0006']).to eq true
-        expect(host_inventory['facter']['self_service']['S0007']).to eq true
+        expect(host_inventory['facter']['self_service']).not_to be_empty
+        expect(host_inventory['facter']['self_service'].filter { |_k, v| !v }).to be_empty
       end
     end
 
@@ -77,11 +72,24 @@ describe 'self_service class' do
         run_shell('rm -f /etc/puppetlabs/facter/facts.d/load_averages.json')
       end
 
-      it 'if S0007 conditions for false are met' do
-        run_shell('fallocate -l $(($(facter -p mountpoints.\'/\'.available_bytes)-1073741824)) /largefile.txt')
-        result = run_shell('facter -p self_service.S0007')
-        expect(result.stdout).to match(%r{false})
-        run_shell('rm -rf  /largefile.txt')
+      context 'when filesystem usage exceeds 80%' do
+        before(:all) do
+          run_shell('fallocate -l $(($(facter -p mountpoints.\'/\'.available_bytes)-1073741824)) /largefile.txt')
+        end
+
+        after(:all) do
+          run_shell('rm -rf  /largefile.txt')
+        end
+
+        it 'sets S0007 to false' do
+          result = run_shell('facter -p self_service.S0007')
+          expect(result.stdout).to match(%r{false})
+        end
+
+        it 'sets S0008 to false' do
+          result = run_shell('facter -p self_service.S0008')
+          expect(result.stdout).to match(%r{false})
+        end
       end
     end
   end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -15,7 +15,7 @@ describe 'self_service class' do
     # Test Confirms all facts are false which is another indicator the class is performing correctly
     describe 'check no self_service fact is false' do
       it 'if idempotent all facts should be true' do
-        expect(host_inventory['facter']['self_service']).not_to be_empty
+        expect(host_inventory['facter']['self_service'].size).to eq(8)
         expect(host_inventory['facter']['self_service'].filter { |_k, v| !v }).to be_empty
       end
     end


### PR DESCRIPTION
Prior to this commit, S0007 used existing facts to check the free disk
space. This commit adds a shared method to check the disk space of an
arbitrary filesytem path and uses it for S0007 and S0008.