### PR TITLE
Adds in PE node confinement types and more status checks

### DIFF
--- a/lib/facter/self_service.rb
+++ b/lib/facter/self_service.rb
@@ -60,4 +60,9 @@ Facter.add(:self_service, type: :aggregate) do
     percent = Facter.value(:pe_postgresql_info)['data_partition_available_bytes'].fdiv(Facter.value(:pe_postgresql_info)['data_partition_size_bytes']) * 100
     { S0007: percent >= 20 }
   end
+  chunk(:S0008) do
+    next unless Facter.value(:pe_build) && Dir.exist?('/etc/puppetlabs/puppetserver')
+    # check codedir data mount has at least 20% free
+    { S0008: `df -m #{Puppet.settings['codedir']}`.split(%r{\b})[26].to_i <= 80 }
+  end
 end

--- a/lib/facter/self_service.rb
+++ b/lib/facter/self_service.rb
@@ -6,6 +6,7 @@ require_relative '../shared/puppet_self_service'
 
 Facter.add(:self_service, type: :aggregate) do
   confine kernel: 'Linux'
+  confine { Facter.value(:pe_build) }
 
   puppet_bin = '/opt/puppetlabs/bin/puppet'
 
@@ -20,13 +21,12 @@ Facter.add(:self_service, type: :aggregate) do
   end
 
   chunk(:S0003) do
-    next unless Facter.value(:pe_build) # Only run on Puppetservers
     # check for noop logic flip as false is the desired state
     { S0003: !Puppet.settings['noop'] }
   end
 
   chunk(:S0004) do
-    next unless Facter.value(:pe_build) && File.exist?('/etc/puppetlabs/client-tools/services.conf') && File.exist?('/opt/puppetlabs/bin/puppet-infrastructure')
+    next unless PuppetSelfService.primary?
     # Is PE and has clienttools covers pe-psql and compilers
     # Check for service status that is not green, potentially need a better way of doing this, or perhaps calling the api directly for each service
     result = Facter::Core::Execution.execute("#{puppet_bin} infrastructure status")
@@ -50,19 +50,37 @@ Facter.add(:self_service, type: :aggregate) do
   end
 
   chunk(:S0006) do
-    next unless Facter.value(:pe_build) # Only run on infrastructure
     # check for sustained load average greater than available cores
     { S0006: Facter.value(:load_averages)['15m'] <= Facter.value(:processors)['count'] }
   end
   chunk(:S0007) do
-    next unless Facter.value(:pe_build) && Facter.value(:pe_postgresql_info)['data_partition_size_bytes'] > 0 # Only run on infrastructure with pe-postgres
+    next unless PuppetSelfService.primary? || PuppetSelfService.replica? || PuppetSelfService.postgres?
     # check postgres data mount has at least 20% free
     percent = Facter.value(:pe_postgresql_info)['data_partition_available_bytes'].fdiv(Facter.value(:pe_postgresql_info)['data_partition_size_bytes']) * 100
     { S0007: percent >= 20 }
   end
   chunk(:S0008) do
-    next unless Facter.value(:pe_build) && Dir.exist?('/etc/puppetlabs/puppetserver')
+    next unless PuppetSelfService.primary? || PuppetSelfService.replica? || PuppetSelfService.compiler? || PuppetSelfService.legacy_compiler?
     # check codedir data mount has at least 20% free
     { S0008: `df -m #{Puppet.settings['codedir']}`.split(%r{\b})[26].to_i <= 80 }
+  end
+
+  chunk(:S0009) do
+    next unless  PuppetSelfService.replica? || PuppetSelfService.compiler? || PuppetSelfService.legacy_compiler? || PuppetSelfService.primary?
+    # Is the Pe-puppetsever Service Running and Enabled
+    { S0009: PuppetSelfService.service_running_enabled('pe-puppetserver') }
+  end
+
+  chunk(:S0010) do
+    next unless PuppetSelfService.replica? || PuppetSelfService.compiler? || PuppetSelfService.primary?
+    # Is the pe-puppetdb Service Running and Enabled
+    { S0010: PuppetSelfService.service_running_enabled('pe-puppetdb') }
+  end
+
+  chunk(:S0011) do
+    next unless PuppetSelfService.replica? || PuppetSelfService.postgres? || PuppetSelfService.primary?
+    # Is the pe-postgres Service Running and Enabled
+    postgresversion = PuppetSelfService.pe_postgres_service_name
+    { S0011: PuppetSelfService.service_running_enabled(postgresversion.to_s) }
   end
 end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -23,6 +23,9 @@ describe 'self_service class' do
         expect(host_inventory['facter']['self_service']['S0006']).to eq true
         expect(host_inventory['facter']['self_service']['S0007']).to eq true
         expect(host_inventory['facter']['self_service']['S0008']).to eq true
+        expect(host_inventory['facter']['self_service']['S0009']).to eq true
+        expect(host_inventory['facter']['self_service']['S0010']).to eq true
+        expect(host_inventory['facter']['self_service']['S0011']).to eq true
       end
     end
 
@@ -85,6 +88,27 @@ describe 'self_service class' do
         result = run_shell('facter -p self_service.S0008')
         expect(result.stdout).to match(%r{false})
         run_shell('rm -rf  /largefile.txt')
+      end
+
+      it 'if S0009 conditions for false are met' do
+        run_shell('puppet resource service pe-puppetserver ensure=stopped')
+        result = run_shell('facter -p self_service.S0009')
+        expect(result.stdout).to match(%r{false})
+        run_shell('puppet resource service pe-puppetserver ensure=running')
+      end
+
+      it 'if S0010 conditions for false are met' do
+        run_shell('puppet resource service pe-puppetdb ensure=stopped')
+        result = run_shell('facter -p self_service.S0010')
+        expect(result.stdout).to match(%r{false})
+        run_shell('puppet resource service pe-puppetdb ensure=running')
+      end
+
+      it 'if S0011 conditions for false are met' do
+        run_shell('puppet resource service pe-postgresql ensure=stopped')
+        result = run_shell('facter -p self_service.S0011')
+        expect(result.stdout).to match(%r{false})
+        run_shell('puppet resource service pe-postgresql ensure=running')
       end
     end
   end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -22,6 +22,7 @@ describe 'self_service class' do
         expect(host_inventory['facter']['self_service']['S0005']).to eq true
         expect(host_inventory['facter']['self_service']['S0006']).to eq true
         expect(host_inventory['facter']['self_service']['S0007']).to eq true
+        expect(host_inventory['facter']['self_service']['S0008']).to eq true
       end
     end
 
@@ -77,9 +78,11 @@ describe 'self_service class' do
         run_shell('rm -f /etc/puppetlabs/facter/facts.d/load_averages.json')
       end
 
-      it 'if S0007 conditions for false are met' do
+      it 'if S0007 and S0008 conditions for false are met' do
         run_shell('fallocate -l $(($(facter -p mountpoints.\'/\'.available_bytes)-1073741824)) /largefile.txt')
         result = run_shell('facter -p self_service.S0007')
+        expect(result.stdout).to match(%r{false})
+        result = run_shell('facter -p self_service.S0008')
         expect(result.stdout).to match(%r{false})
         run_shell('rm -rf  /largefile.txt')
       end


### PR DESCRIPTION
Prior to this commit lengthy statements of node confinement had to be made per chunk

Post this update, the whole fact will be confine to just PE infra nodes, and each chunk can be confined to node types found in out standard / large and XL deployments

primary / replica/ compiler or postgres