### PR TITLE
Adds a filesystem free method

### DIFF
--- a/lib/shared/puppet_self_service.rb
+++ b/lib/shared/puppet_self_service.rb
@@ -114,4 +114,14 @@ module PuppetSelfService
       !service_file_exist?('pe-puppetdb') &&
       service_file_exist?('pe-pgsql/pe-postgresql')
   end
+
+  # Get the free disk percentage from a path
+  # @param name [String] The path on the file system
+  # @return [Integer] The percentage of free disk space on the mount
+  def self.filesystem_free(path)
+    require 'sys/filesystem'
+
+    stat = Sys::Filesystem.stat(path)
+    (stat.blocks_available.to_f / stat.blocks.to_f * 100).to_i
+  end
 end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -15,17 +15,8 @@ describe 'self_service class' do
     # Test Confirms all facts are false which is another indicator the class is performing correctly
     describe 'check no self_service fact is false' do
       it 'if idempotent all facts should be true' do
-        expect(host_inventory['facter']['self_service']['S0001']).to eq true
-        expect(host_inventory['facter']['self_service']['S0002']).to eq true
-        expect(host_inventory['facter']['self_service']['S0003']).to eq true
-        expect(host_inventory['facter']['self_service']['S0004']).to eq true
-        expect(host_inventory['facter']['self_service']['S0005']).to eq true
-        expect(host_inventory['facter']['self_service']['S0006']).to eq true
-        expect(host_inventory['facter']['self_service']['S0007']).to eq true
-        expect(host_inventory['facter']['self_service']['S0008']).to eq true
-        expect(host_inventory['facter']['self_service']['S0009']).to eq true
-        expect(host_inventory['facter']['self_service']['S0010']).to eq true
-        expect(host_inventory['facter']['self_service']['S0011']).to eq true
+        expect(host_inventory['facter']['self_service'].size).to eq(11)
+        expect(host_inventory['facter']['self_service'].filter { |_k, v| !v }).to be_empty
       end
     end
 
@@ -81,13 +72,24 @@ describe 'self_service class' do
         run_shell('rm -f /etc/puppetlabs/facter/facts.d/load_averages.json')
       end
 
-      it 'if S0007 and S0008 conditions for false are met' do
-        run_shell('fallocate -l $(($(facter -p mountpoints.\'/\'.available_bytes)-1073741824)) /largefile.txt')
-        result = run_shell('facter -p self_service.S0007')
-        expect(result.stdout).to match(%r{false})
-        result = run_shell('facter -p self_service.S0008')
-        expect(result.stdout).to match(%r{false})
-        run_shell('rm -rf  /largefile.txt')
+      context 'when filesystem usage exceeds 80%' do
+        before(:all) do
+          run_shell('fallocate -l $(($(facter -p mountpoints.\'/\'.available_bytes)-1073741824)) /largefile.txt')
+        end
+
+        after(:all) do
+          run_shell('rm -rf  /largefile.txt')
+        end
+
+        it 'sets S0007 to false' do
+          result = run_shell('facter -p self_service.S0007')
+          expect(result.stdout).to match(%r{false})
+        end
+
+        it 'sets S0008 to false' do
+          result = run_shell('facter -p self_service.S0008')
+          expect(result.stdout).to match(%r{false})
+        end
       end
 
       it 'if S0009 conditions for false are met' do


### PR DESCRIPTION
Prior to this PR, S0007 used existing facts to check the free disk
space. This PR adds a shared method to check the disk space of an
arbitrary filesytem path and uses it for S0007 and S0008.

Prior to this PR, the acceptance test was checking that all elements
in the fact hash were not false, however it did not specify the number
of elements in the hash This could lead to a scenario where a chunk is
missing and still passes. This PR checks the explicit number of
chunks in the hash.