### PR TITLE
(fix) Do not filter on Undef

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,7 +10,7 @@
 class self_service (
   Array[String[1]] $indicator_exclusions = [],
 ) {
-  $negatives = $facts['self_service'].filter | $k, $v | { $v == false and ! ($k in $indicator_exclusions) }
+  $negatives = getvar('facts.self_service', []).filter | $k, $v | { $v == false and ! ($k in $indicator_exclusions) }
 
   $negatives.each |$indicator, $_v| {
     notify { "Self Service ${indicator}":


### PR DESCRIPTION
Prior to this commit, the class would fail with an error if the
self_service fact was not present. This commit updates the code to
handle a missing self_service fact.

This fixes an issue with the manifest where the `self_service` fact doesn't exist, such as being classified on a non-PE infra node. It also fixes issues where the fact may not be in place when impact analysis runs or other CI-type testing.