### PR TITLE
(SUP-2923) Replace unencrypted git protocol in .fixtures.yaml

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,11 +5,11 @@ fixtures:
   forge_modules:
 #     stdlib: "puppetlabs/stdlib"
   repositories:   
-    facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
-    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'
-    provision: 'https://github.com/puppetlabs/provision.git'
-    bootstrap: "https://github.com/puppetlabs/puppetlabs-bootstrap"
-    puppet_conf: "https://github.com/puppetlabs/puppetlabs-puppet_conf"
-    ruby_task_helper: "https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper"
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
-    deploy_pe: 'git://github.com/jarretlavallee/puppet-deploy_pe.git'
+    facts: 'https://github.com/puppetlabs/puppetlabs-facts'
+    puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent'
+    provision: 'https://github.com/puppetlabs/provision'
+    bootstrap: 'https://github.com/puppetlabs/puppetlabs-bootstrap'
+    puppet_conf: 'https://github.com/puppetlabs/puppetlabs-puppet_conf'
+    ruby_task_helper: 'https://git@github.com/puppetlabs/puppetlabs-ruby_task_helper'
+    stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib'
+    deploy_pe: 'https://github.com/jarretlavallee/puppet-deploy_pe'


### PR DESCRIPTION
# Summary

Per recent changes to [GH security](https://github.blog/2021-09-01-improving-git-protocol-security-github/), updated repo source protocols in `.fixures.yaml`.

# Detailed Description

  * Updated `.fixtures.yaml` to move public repo sources from `git` to `https` protocol.

## Please check off the steps below as you complete each step
- [X] Put the Jira ticket number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review`
- [ ] Update the Scoring Spreadsheet
- [ ] Get a **review** from someone on the support team
- [ ] Get a **review** from @misseuropa, @davidbastedo, or @deleon365
