### PR TITLE
Adding Agent only Fact check for expiring host cert

### DIFF
--- a/lib/facter/agent_self_service.rb
+++ b/lib/facter/agent_self_service.rb
@@ -1,0 +1,17 @@
+# Agent Self service fact aims to have all chunks reporting as true, indicating ideal state, any individual chunk reporting false should be alerted on and checked against documentation for next steps
+# Use shared logic from PuppetSelfService
+
+Facter.add(:agent_self_service, type: :aggregate) do
+  confine { !Facter.value(:pe_build) }
+  require 'puppet'
+
+  chunk(:AS001) do
+    # Is the hostcert expiring within 90 days
+    #
+    raw_hostcert = File.read(Puppet.settings['hostcert'])
+    certificate = OpenSSL::X509::Certificate.new raw_hostcert
+    result = certificate.not_after - Time.now
+
+    { AS001: result > 7_776_000 }
+  end
+end

--- a/spec/acceptance/agent_self_service_spec.rb
+++ b/spec/acceptance/agent_self_service_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper_acceptance'
+# Test Confirms that the agent only fact does not appear on infra components
+describe 'check agent_self_service fact is not on infra components' do
+  it 'agent_self_service should be empty' do
+    expect(host_inventory['facter']['agent_self_service']).to be_nil
+  end
+end


### PR DESCRIPTION
This fact allows for the automation of tasks relating to expiring agent certs in the PE population, by reporting "true" to the puppetdb, if a host cert is due to expire within 90 days
