### PR TITLE
(GH-52) Restrict S0006 to primaries

### DIFF
--- a/lib/facter/self_service.rb
+++ b/lib/facter/self_service.rb
@@ -49,6 +49,7 @@ Facter.add(:self_service, type: :aggregate) do
   end
 
   chunk(:S0006) do
+    next unless PuppetSelfService.primary?
     # Is puppet_metrics_collector running
     { S0006: PuppetSelfService.service_running_enabled('puppet_puppetserver-metrics.timer') }
   end


### PR DESCRIPTION
Prior to this commit, S0006 ran on all infra nodes. The puppet metrics
collector should only run on the primary server in most configurations,
so it should be restricted to the primary. This commit restricts S0006
to the primary server.

Resolves #52 

## Please check off the steps below as you complete each step
- [ ] Put the Jira ticket number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review`
- [ ] Update the Scoring Spreadsheet
- [ ] Get a **review** from someone on the support team
- [ ] Get a **review** from @misseuropa, @davidbastedo, or @deleon365
