### PR TITLE
(maint) Remove contest information from the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,4 @@
 ## Please check off the steps below as you complete each step
-- [ ] Put the Jira ticket number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
-- [ ] Update the Jira ticket status to `Ready for Review`
-- [ ] Update the Scoring Spreadsheet
-- [ ] Get a **review** from someone on the support team
-- [ ] Get a **review** from @misseuropa, @davidbastedo, or @deleon365
+- [ ] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
+- [ ] Update the Jira ticket status to `Ready for Review` if there is one
+- [ ] Review any CI failures and fix issues


### PR DESCRIPTION
Prior to this commit, the PR template had some items that are no longer
relevant. This commit removes those entries from the PR template.