### PR TITLE
(SUP-2945) Updating S0004 to call the services API

### DIFF
--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -60,10 +60,10 @@ describe 'self_service class' do
         run_shell('puppet config set noop false', expect_failures: false)
       end
       it 'if S0004 conditions for false are met' do
-        run_shell('puppet resource service pe-orchestration-services  ensure=stopped')
+        run_shell('puppet resource service pe-puppetserver  ensure=stopped')
         result = run_shell('facter -p self_service.S0004')
         expect(result.stdout).to match(%r{false})
-        run_shell('puppet resource service pe-orchestration-services  ensure=running')
+        run_shell('puppet resource service pe-puppetserver  ensure=running')
       end
 
       it 'if S0006 conditions for false are met' do


### PR DESCRIPTION
 Prior to this PR, S0004 was using puppet infra status to work out Infrastructure services and it was too slow to produce result.
 Post this, S0004 uses a shareable NETT::HTTP function to work out localhost (127.0.0.1) services estate.

## Please check off the steps below as you complete each step
- [x] Put the Jira ticket or Github issue number in parentheses in the **Title** e.g. `(SUP-XXXX) Add Super Duper State Check`
- [ ] Update the Jira ticket status to `Ready for Review` if there is one
- [ ] Review any CI failures and fix issues
