### PR TITLE
Pin octokit version to fix auto release workflowe

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ group :development do
   gem "puppet-module-win-default-r#{minor_version}", '~> 1.0',   require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-win-dev-r#{minor_version}", '~> 1.0',       require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "github_changelog_generator",                              require: false
+  gem "octokit",  "= 4.21.0"
 end
 group :system_tests do
   gem "puppet-module-posix-system-r#{minor_version}", '~> 1.0', require: false, platforms: [:ruby]


### PR DESCRIPTION
New version of oktokit is not compatible with change_log_generator only current resolution is to bin the version.

Or release workflow will get rate limiting errors

May need reverted at a later date