### PR TITLE
(SUP-2918) Update S0039 to parse server access log

### DIFF
--- a/lib/facter/self_service.rb
+++ b/lib/facter/self_service.rb
@@ -273,8 +273,14 @@ Facter.add(:self_service, type: :aggregate) do
   chunk(:S0039) do
     # PuppetServer
     next unless PuppetSelfService.primary? || PuppetSelfService.replica? || PuppetSelfService.compiler? || PuppetSelfService.legacy_compiler?
-    log_path = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetserver/puppetserver.log'
-    search_for_error = `tail -n 500 #{log_path} | grep 'Error 503 on SERVER'`
-    { S0039: search_for_error.empty? }
+    logfile = File.dirname(Puppet.settings['logdir'].to_s) + '/puppetserver/puppetserver-access.log'
+    apache_regex = %r{^(\S+) \S+ (\S+) \[([^\]]+)\] "([A-Z]+) ([^ "]+)? HTTP/[0-9.]+" (?<status>[0-9]{3})}
+
+    has_503 = File.foreach(logfile).any? do |line|
+      match = line.match(apache_regex)
+      match and match[:status] == '503'
+    end
+
+    { S0039: has_503 }
   end
 end

--- a/lib/facter/self_service.rb
+++ b/lib/facter/self_service.rb
@@ -281,6 +281,6 @@ Facter.add(:self_service, type: :aggregate) do
       match and match[:status] == '503'
     end
 
-    { S0039: has_503 }
+    { S0039: !has_503 }
   end
 end

--- a/spec/acceptance/self_service_spec.rb
+++ b/spec/acceptance/self_service_spec.rb
@@ -217,13 +217,15 @@ describe 'self_service class' do
         run_shell('rm -rf /opt/puppetlabs/server/data/packages/public/2018.1.5')
       end
       it 'if S0039 conditions for false are met' do
+        # rubocop:disable Layout/LineLength
         run_shell('export logdir=$(puppet config print logdir) &&
-         cp $logdir/../puppetserver/puppetserver.log $logdir/../puppetserver/puppetserver.log.bk &&
-         echo "Error 503 on SERVER" >> $logdir/../puppetserver/puppetserver.log')
+         cp $logdir/../puppetserver/puppetserver-access.log $logdir/../puppetserver/puppetserver-access.log.bk &&
+         echo "0.0.0.0 - - [04/Feb/2022:17:04:09 +0000] \"PUT /puppet/v3/report/foo.bar.com?environment=production HTTP/1.1\" 503 12 \"-\" \"Agent String\" 91 16051 85" >> $logdir/../puppetserver/puppetserver-access.log')
+        # rubocop:enable Layout/LineLength
         result = run_shell('facter -p self_service.S0039')
         expect(result.stdout).to match(%r{false})
-        run_shell('export logdir=$(puppet config print logdir) && rm -f $logdir/../puppetserver/puppetserver.log &&
-        mv $logdir/../puppetserver/puppetserver.log.bk $logdir/../puppetserver/puppetserver.log')
+        run_shell('export logdir=$(puppet config print logdir) && rm -f $logdir/../puppetserver/puppetserver-access.log &&
+        mv $logdir/../puppetserver/puppetserver-access.log.bk $logdir/../puppetserver/puppetserver-access.log')
       end
       it 'if S0033 conditions for false are met' do
         run_shell('cat <<EOF > /etc/puppetlabs/puppet/hiera.yaml


### PR DESCRIPTION
Prior to this commit, we parsed puppetserver.log log check for 503
errors, but this can be determined from the access logs without the risk
of parsing a huge file with many custom code errors and warnings.  This
commit uses an Apache regex to check if puppetserver-access.log has 503
return codes.